### PR TITLE
Cancel remaining promises using abort signal

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,8 @@ pRace([]);
 //=> [RangeError: Expected the input to contain at least one item]
 
 pRace(signal => [
-	signal => fetch('/api', {signal}),
-	signal => setTimeout(10, {signal}),
+	fetch('/api', {signal}),
+	setTimeout(10, {signal}),
 ]);
 //=> Remaining promises other than first one will be aborted.
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+type IterableOfPromiseLike<ValueType> = Iterable<ValueType | PromiseLike<ValueType>>;
+
 /**
 A better [`Promise.race()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/race).
 
@@ -20,6 +22,4 @@ pRace(signal => [
 //=> Remaining promises other than first one will be aborted.
 ```
 */
-type IterableOfPromiseLike<ValueType> = Iterable<ValueType | PromiseLike<ValueType>>;
-
 export default function pRace<ValueType>(iterableOrExecutor: (IterableOfPromiseLike<ValueType>) | ((signal: AbortSignal) => IterableOfPromiseLike<ValueType>)): Promise<ValueType>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,14 @@ Promise.race([]);
 
 pRace([]);
 //=> [RangeError: Expected the input to contain at least one item]
+
+pRace(signal => [
+	signal => fetch('/api', {signal}),
+	signal => setTimeout(10, {signal}),
+]);
+//=> Remaining promises other than first one will be aborted.
 ```
 */
-export default function pRace<ValueType>(iterable: Iterable<ValueType | PromiseLike<ValueType>>): Promise<ValueType>;
+type PromisibleIterable<ValueType> = Iterable<ValueType | PromiseLike<ValueType>>;
+
+export default function pRace<ValueType>(iterableOrExecutor: (PromisibleIterable<ValueType>) | ((signal: AbortSignal) => PromisibleIterable<ValueType>)): Promise<ValueType>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,6 @@ pRace(signal => [
 //=> Remaining promises other than first one will be aborted.
 ```
 */
-type PromisibleIterable<ValueType> = Iterable<ValueType | PromiseLike<ValueType>>;
+type IterableOfPromiseLike<ValueType> = Iterable<ValueType | PromiseLike<ValueType>>;
 
-export default function pRace<ValueType>(iterableOrExecutor: (PromisibleIterable<ValueType>) | ((signal: AbortSignal) => PromisibleIterable<ValueType>)): Promise<ValueType>;
+export default function pRace<ValueType>(iterableOrExecutor: (IterableOfPromiseLike<ValueType>) | ((signal: AbortSignal) => IterableOfPromiseLike<ValueType>)): Promise<ValueType>;

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ export default async function pRace(executorOrIterable) {
 	}
 
 	const result = await Promise.race(iterable);
-	abortController.abort();
+	abortController?.abort();
 	return result;
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,19 @@
 import isEmptyIterable from 'is-empty-iterable';
 
-export default async function pRace(iterable) {
+const toIterable = (executorOrIterable, signal) => {
+	return typeof executorOrIterable === 'function' ? executorOrIterable(signal) : executorOrIterable;
+};
+
+export default async function pRace(executorOrIterable) {
+	const abortController = globalThis.AbortController ? new AbortController() : undefined;
+
+	const iterable = toIterable(executorOrIterable, abortController?.signal);
+
 	if (isEmptyIterable(iterable)) {
 		throw new RangeError('Expected the iterable to contain at least one item');
 	}
 
-	return Promise.race(iterable);
+	const result = await Promise.race(iterable);
+	abortController.abort();
+	return result;
 }

--- a/index.js
+++ b/index.js
@@ -7,13 +7,17 @@ const toIterable = (executorOrIterable, signal) => {
 export default async function pRace(executorOrIterable) {
 	const abortController = globalThis.AbortController ? new AbortController() : undefined;
 
-	const iterable = toIterable(executorOrIterable, abortController?.signal);
+	const iterable = toIterable(executorOrIterable, abortController ? abortController.signal : undefined);
 
 	if (isEmptyIterable(iterable)) {
 		throw new RangeError('Expected the iterable to contain at least one item');
 	}
 
 	const result = await Promise.race(iterable);
-	abortController?.abort();
+
+	if (abortController) {
+		abortController.abort();
+	}
+
 	return result;
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,3 +3,5 @@ import pRace from './index.js';
 
 expectType<Promise<string>>(pRace(['foo', Promise.resolve('bar')]));
 expectType<Promise<number>>(pRace(new Set([1, Promise.resolve(2)])));
+expectType<Promise<string>>(pRace(() => ['foo', Promise.resolve('bar')]));
+expectType<Promise<number>>(pRace(() => new Set([1, Promise.resolve(2)])));

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,14 @@
 
 > A better [`Promise.race()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/race)
 
-- This fixes the [silly behavior](https://github.com/domenic/promises-unwrapping/issues/75) of `Promise.race()` returning a forever pending promise when supplied an empty iterable, which could create some really hard to debug problems. `Promise.race()` returns the first promise to fulfill or reject. Check out [`p-any`](https://github.com/sindresorhus/p-any) if you like to get the first promise to fulfill.
-
-- Support to cancel other promises using [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) when resolving the first promise. This works with Node.js 16 or higher.
+Improvements:
+- Fixes the [silly behavior](https://github.com/domenic/promises-unwrapping/issues/75) of `Promise.race()` returning a forever pending promise when supplied an empty iterable, which could create some really hard to debug problems. `Promise.race()` returns the first promise to fulfill or reject. Check out [`p-any`](https://github.com/sindresorhus/p-any) if you like to get the first promise to fulfill.
+- Supports aborting promises using [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 
 ## Install
 
-```
-$ npm install p-race
+```sh
+npm install p-race
 ```
 
 ## Usage
@@ -22,12 +22,6 @@ Promise.race([]);
 
 pRace([]);
 //=> [RangeError: Expected the input to contain at least one item]
-
-pRace(signal => [
-	signal => fetch('/api', {signal}),
-	signal => setTimeout(10, {signal}),
-]);
-// Remaining promises other than first one will be aborted.
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 
 > A better [`Promise.race()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/race)
 
-This fixes the [silly behavior](https://github.com/domenic/promises-unwrapping/issues/75) of `Promise.race()` returning a forever pending promise when supplied an empty iterable, which could create some really hard to debug problems.
+- This fixes the [silly behavior](https://github.com/domenic/promises-unwrapping/issues/75) of `Promise.race()` returning a forever pending promise when supplied an empty iterable, which could create some really hard to debug problems. `Promise.race()` returns the first promise to fulfill or reject. Check out [`p-any`](https://github.com/sindresorhus/p-any) if you like to get the first promise to fulfill.
 
-`Promise.race()` returns the first promise to fulfill or reject. Check out [`p-any`](https://github.com/sindresorhus/p-any) if you like to get the first promise to fulfill.
+- Support to cancel other promises using [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) when resolving the first promise. This works with Node.js 16 or higher.
 
 ## Install
 
@@ -27,12 +27,32 @@ pRace(signal => [
 	signal => fetch('/api', {signal}),
 	signal => setTimeout(10, {signal}),
 ]);
-//=> Remaining promises other than first one will be aborted.
+// Remaining promises other than first one will be aborted.
 ```
 
 ## API
 
+### pRace(signal)
+
 See the [`Promise.race()` docs](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/race).
+
+#### signal
+
+Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+
+You can pass the `signal` object to abort remaining promises when resolve the first promise.
+
+*Requires Node.js 16 or later.*
+
+```js
+import pRace from 'p-race';
+
+pRace(signal => [
+	signal => fetch('/api', {signal}),
+	signal => setTimeout(10, {signal}),
+]);
+// Remaining promises other than first one will be aborted.
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ pRace([]);
 
 ## API
 
-### pRace(executor | iterable)
+### pRace(iterable | executor)
 
 #### iterable
 
@@ -40,7 +40,7 @@ Type: `signal => Iterable<Promise|any>`
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 
-You can use `signal` to each iterable's element to abort remaining promises when resolve the first promise.
+You can pass the `signal` to each iterable's element to abort remaining promises when resolve the first promise.
 
 *Requires Node.js 16 or later.*
 
@@ -51,7 +51,7 @@ pRace(signal => [
 	fetch('/api', {signal}),
 	setTimeout(10, {signal}),
 ]);
-// Remaining promises other than first one will be aborted.
+//=> Remaining promises other than first one will be aborted.
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -34,13 +34,13 @@ Type: `Iterable<Promise|any>`
 
 #### executor
 
-Type: `(signal: AbortSignal) => Iterable<Promise|any>`
+Type: `signal => Iterable<Promise|any>`
 
 ##### signal
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 
-You can pass the `signal` object to abort remaining promises when resolve the first promise.
+You can use `signal` to each iterable's element to abort remaining promises when resolve the first promise.
 
 *Requires Node.js 16 or later.*
 
@@ -48,8 +48,8 @@ You can pass the `signal` object to abort remaining promises when resolve the fi
 import pRace from 'p-race';
 
 pRace(signal => [
-	signal => fetch('/api', {signal}),
-	signal => setTimeout(10, {signal}),
+	fetch('/api', {signal}),
+	setTimeout(10, {signal}),
 ]);
 // Remaining promises other than first one will be aborted.
 ```

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,12 @@ Promise.race([]);
 
 pRace([]);
 //=> [RangeError: Expected the input to contain at least one item]
+
+pRace(signal => [
+	signal => fetch('/api', {signal}),
+	signal => setTimeout(10, {signal}),
+]);
+//=> Remaining promises other than first one will be aborted.
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -26,11 +26,17 @@ pRace([]);
 
 ## API
 
-### pRace(signal)
+### pRace(executor | iterable)
 
-See the [`Promise.race()` docs](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/race).
+#### iterable
 
-#### signal
+Type: `Iterable<Promise|any>`
+
+#### executor
+
+Type: `(signal: AbortSignal) => Iterable<Promise|any>`
+
+##### signal
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 

--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,11 @@ pRace([]);
 
 #### iterable
 
-Type: `Iterable<Promise|any>`
+Type: `Iterable<Promise | unknown>`
 
 #### executor
 
-Type: `signal => Iterable<Promise|any>`
+Type: `signal => Iterable<Promise | unknown>`
 
 ##### signal
 
@@ -51,7 +51,7 @@ pRace(signal => [
 	fetch('/api', {signal}),
 	setTimeout(10, {signal}),
 ]);
-//=> Remaining promises other than first one will be aborted.
+// Remaining promises other than first one will be aborted.
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -9,3 +9,39 @@ test('works like Promise.race()', async t => {
 test('handles empty Iterable', async t => {
 	await t.throwsAsync(pRace([]), {instanceOf: RangeError});
 });
+
+if (globalThis.AbortController !== undefined) {
+	test('abortsignal', async t => {
+		let signalReference;
+
+		t.is(await pRace(signal => {
+			signalReference = signal;
+
+			return [
+				delay(50, {value: 1, signal}),
+				delay(100, {value: 2, signal})
+			];
+		}), 1);
+
+		t.true(signalReference.aborted);
+	});
+
+	test('abortsignal - should throw error', async t => {
+		let signalReference;
+
+		await t.throwsAsync(
+			pRace(signal => {
+				signalReference = signal;
+
+				return [
+					delay(50, {value: Promise.reject(new Error('some error')), signal}),
+					delay(100, {value: 1, signal})
+				];
+			}), {
+				message: 'some error'
+			}
+		);
+
+		t.false(signalReference.aborted);
+	});
+}


### PR DESCRIPTION
Fixes #4.

## Notes

1. I made `iterable` to `executorOrIterable` using union, to not break existing code.
2. I think `PromisibleIterable` would be not a good name, but I use the name to try to simplify the type code.
3. If AbortController not exist on globalThis, `signal` argument will be `undefined`.